### PR TITLE
fix(auth): clear token cookie on signout

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -159,6 +159,9 @@ export const signin = async (req, res) => {
 //@access Public
 
 export const signout = (req, res) => {
+  res.cookie("token", "", {
+    maxAge: 0,
+  });
   res.status(200).json({
     success: true,
     message: "You have successfully signed out",


### PR DESCRIPTION
The signout endpoint now clears the authentication token cookie by setting its maxAge to 0. This ensures proper session termination when users sign out.